### PR TITLE
feat: Implement gitops apply command

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,0 +1,57 @@
+/*
+Copyright © 2024 ThreatKey, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/threatkey-oss/hvresult/internal/gitops"
+)
+
+// applyCmd represents the apply command
+var applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply Vault policy and auth roles from a local directory to Vault",
+	Long: `This command reads Vault policy and auth role configurations from a local
+directory and applies them to the Vault server. It can be used to synchronize
+the state of your Vault server with a GitOps repository.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var (
+			ctx          = context.Background()
+			_f           = cmd.Flags()
+			directory, _ = _f.GetString("directory")
+		)
+
+		vc, err := vault.NewClient(vault.DefaultConfig())
+		if err != nil {
+			log.Fatal().Err(err).Msg("error creating Vault client from defaults")
+		}
+
+		if err := gitops.ApplyChanges(ctx, vc, filepath.Join(directory, "auth"), filepath.Join(directory, "sys", "policies", "acl")); err != nil {
+			log.Fatal().Err(err).Msg("error applying changes to Vault")
+		}
+		log.Info().Msg("Successfully applied changes to Vault.")
+	},
+}
+
+func init() {
+	gitopsCmd.AddCommand(applyCmd)
+}

--- a/internal/gitops/apply.go
+++ b/internal/gitops/apply.go
@@ -1,0 +1,225 @@
+package gitops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+)
+
+// ApplyChanges applies local Vault policy and auth role configurations to Vault.
+func ApplyChanges(ctx context.Context, vc *vault.Client, authDirectory, policyDirectory string) error {
+	log.Info().Msg("Applying changes to Vault...")
+
+	if err := applyPolicyChanges(ctx, vc, policyDirectory); err != nil {
+		return fmt.Errorf("error applying policy changes: %w", err)
+	}
+
+	if err := applyAuthChanges(ctx, vc, authDirectory); err != nil {
+		return fmt.Errorf("error applying auth changes: %w", err)
+	}
+
+	return nil
+}
+
+func applyPolicyChanges(ctx context.Context, vc *vault.Client, policyDirectory string) error {
+	log.Info().Str("directory", policyDirectory).Msg("Applying policy changes...")
+
+	// Get existing policies from Vault
+	existingPolicies, err := vc.Sys().ListPoliciesWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing existing policies from Vault: %w", err)
+	}
+
+	// Read local policy files
+	localPolicies := make(map[string]string)
+	err = filepath.WalkDir(policyDirectory, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		policyName := d.Name()
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("error reading local policy file %s: %w", path, err)
+		}
+		localPolicies[policyName] = string(content)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error walking policy directory: %w", err)
+	}
+
+	var eg errgroup.Group
+	eg.SetLimit(5)
+
+	// Apply/Update policies
+	for name, content := range localPolicies {
+		name := name
+		content := content
+		eg.Go(func() error {
+			log.Debug().Str("policy", name).Msg("Writing policy to Vault")
+			if err := vc.Sys().PutPolicyWithContext(ctx, name, content); err != nil {
+				return fmt.Errorf("error writing policy %s to Vault: %w", name, err)
+			}
+			return nil
+		})
+	}
+
+	// Delete policies not present locally
+	for _, existingPolicy := range existingPolicies {
+		existingPolicy := existingPolicy
+		// Skip deleting root and default policies
+		if existingPolicy == "root" || existingPolicy == "default" {
+			log.Debug().Str("policy", existingPolicy).Msg("Skipping deletion of protected policy")
+			continue
+		}
+		if _, exists := localPolicies[existingPolicy]; !exists {
+				eg.Go(func() error {
+					log.Debug().Str("policy", existingPolicy).Msg("Deleting policy from Vault")
+					if err := vc.Sys().DeletePolicyWithContext(ctx, existingPolicy); err != nil {
+						return fmt.Errorf("error deleting policy %s from Vault: %w", existingPolicy, err)
+					}
+					return nil
+				})
+		}
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	log.Info().Msg("Policy changes applied successfully.")
+	return nil
+}
+
+func applyAuthChanges(ctx context.Context, vc *vault.Client, authDirectory string) error {
+	log.Info().Str("directory", authDirectory).Msg("Applying auth role changes...")
+
+	// Get existing auth mounts from Vault
+	mounts, err := vc.Sys().ListAuthWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing auth mounts from Vault: %w", err)
+	}
+
+	// Iterate over each auth mount
+	for mountName, mount := range mounts {
+		mountName := strings.TrimSuffix(mountName, "/")
+		mount := mount
+
+		log.Debug().Str("mount", mountName).Msg("Processing auth mount")
+
+		// Determine the path to roles/users/groups for this mount type
+		var rolePathPrefix string
+		switch mount.Type {
+		case "aws", "gcp":
+			rolePathPrefix = "roles"
+		case "azure", "kubernetes", "oidc", "oci", "saml", "approle":
+			rolePathPrefix = "role"
+		case "kerberos":
+			rolePathPrefix = "groups"
+		case "ldap", "okta":
+			rolePathPrefix = "groups"
+		case "radius":
+			rolePathPrefix = "users"
+		case "token":
+			rolePathPrefix = "roles"
+		default:
+			log.Warn().Str("mount_type", mount.Type).Msg("Unsupported auth mount type, skipping")
+			continue
+		}
+
+		localMountDir := filepath.Join(authDirectory, mountName, rolePathPrefix)
+		log.Debug().Str("local_mount_dir", localMountDir).Msg("Reading local auth roles for mount")
+
+		localRoles := make(map[string]map[string]interface{})
+		err = filepath.WalkDir(localMountDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			roleName := d.Name()
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("error reading local auth role file %s: %w", path, err)
+			}
+			var roleData map[string]interface{}
+			if err := json.Unmarshal(content, &roleData); err != nil {
+				return fmt.Errorf("error unmarshalling local auth role file %s: %w", path, err)
+			}
+			localRoles[roleName] = roleData
+			return nil
+		})
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("error walking local auth mount directory %s: %w", localMountDir, err)
+		}
+
+		// Get existing roles for this mount from Vault
+		listPath := fmt.Sprintf("auth/%s/%s", mountName, rolePathPrefix)
+		secret, err := vc.Logical().ListWithContext(ctx, listPath)
+		if err != nil {
+			return fmt.Errorf("error listing existing roles for mount %s from Vault: %w", mountName, err)
+		}
+
+		existingRoles := make(map[string]bool)
+		if secret != nil && secret.Data != nil {
+			if keys, ok := secret.Data["keys"].([]interface{}); ok {
+				for _, key := range keys {
+					if s, ok := key.(string); ok {
+						existingRoles[s] = true
+					}
+				}
+			}
+		}
+
+		var egMount errgroup.Group
+		egMount.SetLimit(5)
+
+		// Apply/Update roles
+		for name, data := range localRoles {
+			name := name
+			data := data
+			egMount.Go(func() error {
+				writePath := fmt.Sprintf("auth/%s/%s/%s", mountName, rolePathPrefix, name)
+				log.Debug().Str("role", name).Str("path", writePath).Msg("Writing auth role to Vault")
+				if _, err := vc.Logical().WriteWithContext(ctx, writePath, data); err != nil {
+					return fmt.Errorf("error writing auth role %s to Vault: %w", name, err)
+				}
+				return nil
+			})
+		}
+
+		// Delete roles not present locally
+		for existingRole := range existingRoles {
+			existingRole := existingRole
+			if _, exists := localRoles[existingRole]; !exists {
+				egMount.Go(func() error {
+					deletePath := fmt.Sprintf("auth/%s/%s/%s", mountName, rolePathPrefix, existingRole)
+					log.Debug().Str("role", existingRole).Str("path", deletePath).Msg("Deleting auth role from Vault")
+					if _, err := vc.Logical().DeleteWithContext(ctx, deletePath); err != nil {
+						return fmt.Errorf("error deleting auth role %s from Vault: %w", existingRole, err)
+					}
+					return nil
+				})
+			}
+		}
+
+		if err := egMount.Wait(); err != nil {
+			return err
+		}
+	}
+
+	log.Info().Msg("Auth role changes applied successfully.")
+	return nil
+}

--- a/internal/gitops/apply_test.go
+++ b/internal/gitops/apply_test.go
@@ -1,0 +1,213 @@
+package gitops_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/threatkey-oss/hvresult/internal/gitops"
+	"github.com/threatkey-oss/hvresult/internal/testcluster"
+)
+
+func TestApplyChanges(t *testing.T) {
+	ctx := context.Background()
+	vc := testcluster.NewTestCluster(t)
+
+	tempDir, err := os.MkdirTemp("", "hvresult-apply-test-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	authDir := filepath.Join(tempDir, "auth")
+	policyDir := filepath.Join(tempDir, "sys", "policies", "acl")
+
+	// Create some dummy policy and auth role files
+	// Policy 1
+	policy1Content := `path "secret/data/foo" { capabilities = ["read"] }`
+	policy1Path := filepath.Join(policyDir, "test-policy-1")
+	_ = os.MkdirAll(filepath.Dir(policy1Path), 0o755)
+	_ = os.WriteFile(policy1Path, []byte(policy1Content), 0o644)
+
+	// Policy 2
+	policy2Content := `path "secret/data/bar" { capabilities = ["list"] }`
+	policy2Path := filepath.Join(policyDir, "test-policy-2")
+	_ = os.MkdirAll(filepath.Dir(policy2Path), 0o755)
+	_ = os.WriteFile(policy2Path, []byte(policy2Content), 0o644)
+
+	// Auth Role (example: approle)
+	approleRoleContent := `{"token_policies": ["test-policy-1"]}`
+	approleRolePath := filepath.Join(authDir, "approle", "role", "test-approle-role")
+	_ = os.MkdirAll(filepath.Dir(approleRolePath), 0o755)
+	_ = os.WriteFile(approleRolePath, []byte(approleRoleContent), 0o644)
+
+	// Enable approle auth method in Vault
+	_ = vc.Sys().EnableAuthWithOptions("approle", &vault.EnableAuthOptions{Type: "approle"})
+
+	// Test initial apply
+	err = gitops.ApplyChanges(ctx, vc, authDir, policyDir)
+	if err != nil {
+		t.Fatalf("initial ApplyChanges failed: %v", err)
+	}
+
+	// Verify policies are created
+	policy1, err := vc.Sys().GetPolicyWithContext(ctx, "test-policy-1")
+	if err != nil || policy1 != policy1Content {
+		t.Errorf("policy test-policy-1 not applied correctly: %v, %s", err, policy1)
+	}
+	policy2, err := vc.Sys().GetPolicyWithContext(ctx, "test-policy-2")
+	if err != nil || policy2 != policy2Content {
+		t.Errorf("policy test-policy-2 not applied correctly: %v, %s", err, policy2)
+	}
+
+	// Verify approle role is created
+	approleRole, err := vc.Logical().ReadWithContext(ctx, "auth/approle/role/test-approle-role")
+	if err != nil {
+		t.Errorf("error reading approle role: %v", err)
+	}
+	if approleRole == nil {
+		t.Errorf("approle role is nil")
+	}
+	if policies, ok := approleRole.Data["token_policies"].([]interface{}); !ok || len(policies) == 0 || policies[0] != "test-policy-1" {
+		t.Errorf("approle role token_policies not correct: %v", policies)
+	}
+
+	// Test update: modify policy 1, add policy 3, delete policy 2
+	policy1UpdatedContent := `path "secret/data/foo" { capabilities = ["read", "update"] }`
+	_ = os.WriteFile(policy1Path, []byte(policy1UpdatedContent), 0o644)
+
+	policy3Content := `path "secret/data/baz" { capabilities = ["create"] }`
+	policy3Path := filepath.Join(policyDir, "test-policy-3")
+	_ = os.MkdirAll(filepath.Dir(policy3Path), 0o755)
+	_ = os.WriteFile(policy3Path, []byte(policy3Content), 0o644)
+
+	_ = os.Remove(policy2Path)
+
+	// Test update to auth role
+	approleRoleUpdatedContent := `{"token_policies": ["test-policy-3"]}`
+	_ = os.WriteFile(approleRolePath, []byte(approleRoleUpdatedContent), 0o644)
+
+	err = gitops.ApplyChanges(ctx, vc, authDir, policyDir)
+	if err != nil {
+		t.Fatalf("update ApplyChanges failed: %v", err)
+	}
+
+	// Verify policy 1 is updated
+	policy1, err = vc.Sys().GetPolicyWithContext(ctx, "test-policy-1")
+	if err != nil || policy1 != policy1UpdatedContent {
+		t.Errorf("policy test-policy-1 not updated correctly: %v, %s", err, policy1)
+	}
+
+	// Verify policy 2 is deleted
+	policiesAfterUpdate, err := vc.Sys().ListPoliciesWithContext(ctx)
+	if err != nil {
+		t.Fatalf("failed to list policies after update: %v", err)
+	}
+	foundPolicy2 := false
+	for _, p := range policiesAfterUpdate {
+		if p == "test-policy-2" {
+			foundPolicy2 = true
+			break
+		}
+	}
+	if foundPolicy2 {
+		t.Errorf("policy test-policy-2 not deleted correctly")
+	}
+
+	// Verify policy 3 is created
+	policy3, err := vc.Sys().GetPolicyWithContext(ctx, "test-policy-3")
+	if err != nil || policy3 != policy3Content {
+		t.Errorf("policy test-policy-3 not created correctly: %v, %s", err, policy3)
+	}
+
+	// Verify approle role is updated
+	approleRole, err = vc.Logical().ReadWithContext(ctx, "auth/approle/role/test-approle-role")
+	if err != nil {
+		t.Errorf("error reading approle role: %v", err)
+	}
+	if approleRole == nil {
+		t.Errorf("approle role is nil")
+	}
+	if policies, ok := approleRole.Data["token_policies"].([]interface{}); !ok || len(policies) == 0 || policies[0] != "test-policy-3" {
+		t.Errorf("approle role token_policies not correct: %v", policies)
+	}
+
+	// Test idempotency: run apply again with no changes
+	err = gitops.ApplyChanges(ctx, vc, authDir, policyDir)
+	if err != nil {
+		t.Fatalf("idempotency test failed: %v", err)
+	}
+
+	// Verify state is still correct after idempotency run
+	policy1, err = vc.Sys().GetPolicyWithContext(ctx, "test-policy-1")
+	if err != nil || policy1 != policy1UpdatedContent {
+		t.Errorf("idempotency: policy test-policy-1 not correct: %v, %s", err, policy1)
+	}
+	policiesAfterIdempotency, err := vc.Sys().ListPoliciesWithContext(ctx)
+		if err != nil {
+			t.Fatalf("idempotency: failed to list policies: %v", err)
+		}
+		foundPolicy2Idempotency := false
+		for _, p := range policiesAfterIdempotency {
+			if p == "test-policy-2" {
+				foundPolicy2Idempotency = true
+				break
+			}
+		}
+		if foundPolicy2Idempotency {
+			t.Errorf("idempotency: policy test-policy-2 not deleted")
+		}
+	policy3, err = vc.Sys().GetPolicyWithContext(ctx, "test-policy-3")
+	if err != nil || policy3 != policy3Content {
+		t.Errorf("idempotency: policy test-policy-3 not correct: %v, %s", err, policy3)
+	}
+	approleRole, err = vc.Logical().ReadWithContext(ctx, "auth/approle/role/test-approle-role")
+	if err != nil {
+		t.Errorf("idempotency: error reading approle role: %v", err)
+	}
+	if approleRole == nil {
+		t.Errorf("idempotency: approle role is nil")
+	}
+	if policies, ok := approleRole.Data["token_policies"].([]interface{}); !ok || len(policies) == 0 || policies[0] != "test-policy-3" {
+		t.Errorf("idempotency: approle role token_policies not correct: %v", policies)
+	}
+}
+
+func TestPolicyDeletion(t *testing.T) {
+	ctx := context.Background()
+	vc := testcluster.NewTestCluster(t)
+
+	policyName := "test-delete-policy"
+	policyContent := `path "secret/data/delete" { capabilities = ["read"] }`
+
+	// Create the policy
+	err := vc.Sys().PutPolicyWithContext(ctx, policyName, policyContent)
+	if err != nil {
+		t.Fatalf("failed to create policy for deletion test: %v", err)
+	}
+
+	// Verify it exists
+	_, err = vc.Sys().GetPolicyWithContext(ctx, policyName)
+	if err != nil {
+		t.Fatalf("policy %s not found after creation: %v", policyName, err)
+	}
+
+	// Delete the policy
+	err = vc.Sys().DeletePolicyWithContext(ctx, policyName)
+	if err != nil {
+		t.Fatalf("failed to delete policy %s: %v", policyName, err)
+	}
+
+	// Verify it's deleted (expect it not to be in the list)
+	policies, err := vc.Sys().ListPoliciesWithContext(ctx)
+	if err != nil {
+		t.Fatalf("failed to list policies after deletion: %v", err)
+	}
+	for _, p := range policies {
+		if p == policyName {
+			t.Errorf("policy %s found in list after deletion", policyName)
+		}
+	}
+}


### PR DESCRIPTION
This commit introduces the  command, which allows users to
synchronize their local Vault policy and authentication role configurations
with a Vault server.

The command reads policy and role definitions from a local directory,
compares them with the current state in Vault, and applies the necessary
create, update, or delete operations to bring Vault into sync with the
local configuration.

This completes the GitOps loop for Vault policy and role management,
as requested in the README.md.

The implementation includes:
- New  for the Cobra command.
- New  containing the core logic for applying
  policy and auth role changes.
- Comprehensive unit and integration tests in 
  to ensure correctness and idempotency.
- Fixes for test suite issues encountered during development.